### PR TITLE
Dev playlist and targetcollection

### DIFF
--- a/toolsHCK.ps1
+++ b/toolsHCK.ps1
@@ -1112,12 +1112,16 @@ function listtests {
     if (-Not ($WntdPI = $WntdProject.GetProductInstances() | Where-Object { $_.OSPlatform -eq $WntdMachine.OSPlatform })) { throw "Machine pool not targeted in the project." }
     if (-Not ($WntdPITarget = $WntdPI.GetTargets() | Where-Object { ($_.Key -eq $WntdTarget.Key) -and ($_.Machine.Equals($WntdMachine)) })) { throw "The target is not being targeted by the project." }
 
+    $WntdTests = New-Object System.Collections.ArrayList
+
     if (-Not [String]::IsNullOrEmpty($playlist)) {
         $PlaylistManager = New-Object Microsoft.Windows.Kits.Hardware.ObjectModel.PlaylistManager $WntdProject
         $WntdPlaylist = [Microsoft.Windows.Kits.Hardware.ObjectModel.PlaylistManager]::DeserializePlaylist($playlist)
-        $WntdTests = $PlaylistManager.GetTestsFromProjectThatMatchPlaylist($WntdPlaylist)
+        foreach ($tTest in $PlaylistManager.GetTestsFromProjectThatMatchPlaylist($WntdPlaylist)) {
+            if ($tTest.GetTestTargets() | Where-Object { $_.Equals($WntdPITarget) }) { $WntdTests.Add($tTest) | Out-Null }
+        }
     } else {
-         $WntdTests = $WntdPITarget.GetTests()
+         $WntdTests.AddRange($WntdPITarget.GetTests())
     }
 
     if (-Not $json) {


### PR DESCRIPTION
1. Fixed listtests playlist functionality bug
BUG: listtests with playlist applies a playlist on a project and returns
     every test in every target that is being targeted in the project.

Now, only the wanted specific target's tests that match the playlist are
returned.

2. Fixed listtests for TargetCollection target type
BUG: listtests on a target of type TargetCollection returned with
     failure message "The target is not being targeted by the project."

Now, listtests works as expected and returns the tests of the
TargetCollection.
